### PR TITLE
New RSFC page and fixed some links visually

### DIFF
--- a/docs/tools/fair.rst
+++ b/docs/tools/fair.rst
@@ -15,4 +15,5 @@ The following resources in this section are part of the FAIR Tools component.
     FAIRsharing <fair/fairsharing>
     FAIR Assessment Authoring Tool <fair/fair-assessment-authoring-tool>
     FAIR Validator <fair/fair-validator>
+    RSFC <fair/rsfc>
 

--- a/docs/tools/fair/fairos.rst
+++ b/docs/tools/fair/fairos.rst
@@ -1,7 +1,7 @@
 FAIROS
 ^^^^^^
 
-FAIROs is a FAIR assessment tool for [Research Objects](https://www.researchobject.org/ro-crate/). The tool uses external tools such as [F-UJI](https://f-uji.net/), [FOOPS](https://w3id.org/foops/) and [RSFC](https://github.com/oeg-upm/rsfc) to assess datasets, ontologies and software. The catalog contains the metrics and tests used to evaluate Research Objects. The source code with the FTR specification is in the branch dev-ostrails.
+FAIROs is a FAIR assessment tool for `Research Objects <https://www.researchobject.org/ro-crate/>`_. The tool uses external tools such as `F-UJI <https://f-uji.net/>`_, `FOOPS <https://w3id.org/foops/>`_ and `RSFC <https://github.com/oeg-upm/rsfc>`_ to assess datasets, ontologies and software. The catalog contains the metrics and tests used to evaluate Research Objects. The source code with the FTR specification is in the branch dev-ostrails.
 
     - **Persistent identifier**: https://w3id.org/FAIROS/
     - **Zenodo link (latest release)**: https://doi.org/10.5281/zenodo.7795727

--- a/docs/tools/fair/foops.rst
+++ b/docs/tools/fair/foops.rst
@@ -3,7 +3,7 @@
 FOOPS!
 ^^^^^^
 
-The Ontology Pitfall Scanner for FAIR (FOOPS!) is a FAIR assessment tool for vocabularies and ontologies. In this release, FOOPS! has been adapted to comply with the [FTR specification](https://w3id.org/ftr/). A catalog of test descriptions and metrics has been made available in https://w3id.org/foops/catalogue. The release contains the source code of the tools, as well as the machine-readable and human-readable documentation of all tests, metrics and benchmarks associated with the tool.
+The Ontology Pitfall Scanner for FAIR (FOOPS!) is a FAIR assessment tool for vocabularies and ontologies. In this release, FOOPS! has been adapted to comply with the `FTR specification <https://w3id.org/ftr/>`_. A `catalog of test descriptions and metrics <https://w3id.org/foops/catalogue>`_ has been made available. The release contains the source code of the tools, as well as the machine-readable and human-readable documentation of all tests, metrics and benchmarks associated with the tool.
 
     - **Persistent identifier**: https://w3id.org/foops/
     - **Zenodo link (latest release)**: https://doi.org/10.5281/zenodo.14767999

--- a/docs/tools/fair/rsfc.rst
+++ b/docs/tools/fair/rsfc.rst
@@ -1,0 +1,14 @@
+.. _tool-rsfc:
+
+RSFC
+^^^^^^
+
+RSFC (Research Software FAIRness Checks) is a tool designed to evaluate how well a research software's repository complies with the FAIR principles (Findable, Accessible, Interoperable and Reusable).
+
+    - **Persistent identifier**: https://w3id.org/rsfc/
+    - **Zenodo link (latest release)**: https://doi.org/10.5281/zenodo.19554471
+    - **Code repository**: https://github.com/oeg-upm/rsfc
+    - **Version**: 0.1.5
+    - **Release**: https://github.com/oeg-upm/rsfc/releases/tag/v0.1.5
+    - **License**: MIT
+    - **Catalog of tests and metrics**: https://w3id.org/rsfc/catalogue


### PR DESCRIPTION
- Added a RSFC page rsfc.rst to the FAIR Tools section of the documentation along with the necessary changes to integrate it
- Fixed some links so they do not appear with markdown syntax
- Changes made to fair.rst, foops.rst, fairos.rst


Tested locally and works